### PR TITLE
Prevent HTTP error when users are missing overall read permission.

### DIFF
--- a/src/main/resources/hudson/plugins/sectioned_view/SectionedViewPageDecorator/header.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/SectionedViewPageDecorator/header.jelly
@@ -22,5 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <link type="text/css" rel="stylesheet" href="${resURL}/plugin/sectioned-view/sectioned-view.css" />
+  <l:hasPermission permission="${app.READ}">
+    <link type="text/css" rel="stylesheet" href="${resURL}/plugin/sectioned-view/sectioned-view.css" />
+  </l:hasPermission>
 </j:jelly>


### PR DESCRIPTION
Without overall read, this stylesheet isn't needed anyway.
