### PR TITLE
Display trend name as header of compiler warnings trends in Job Graphs Section

### DIFF
--- a/src/main/resources/hudson/plugins/sectioned_view/JobGraphsSection/hudson.plugins.warnings.WarningsProjectAction-sectionFloatingBox.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/JobGraphsSection/hudson.plugins.warnings.WarningsProjectAction-sectionFloatingBox.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
   <j:if test="${action.isTrendVisible(request)}">
     <div class="test-trend-caption">
-      ${%Compiler Warnings Trend}
+      ${action.trendName}
     </div>
     <a href="${relativeUrl}${action.urlName}/">
       <img src="${relativeUrl}${action.urlName}/trendGraph/png?width=${width}&amp;height=${height}"/>


### PR DESCRIPTION
In "Job Graphs Section" when you have multiple graphs per job the header of each graph was hard-coded as "Compiler Warnings Trend" until now. This change is to display the "real" name of the graph, i.e. the trend name.
