### PR TITLE
[JENKINS-8276] Moved method that tests for job filter extenstions fro…

### DIFF
--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
@@ -104,8 +104,12 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
         return jobFilters;
     }
 
+    /**
+     * @deprecated use {@link SectionedViewSectionDescriptor#hasJobFilterExtensions()} instead
+     */
+    @Deprecated
     public boolean hasJobFilterExtensions() {
-        return !ViewJobFilter.all().isEmpty();
+        return getDescriptor().hasJobFilterExtensions();
     }
 
 	public Width getWidth() {

--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSectionDescriptor.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSectionDescriptor.java
@@ -55,6 +55,10 @@ public abstract class SectionedViewSectionDescriptor extends Descriptor<Sectione
 	protected SectionedViewSectionDescriptor() {
 	}
 
+    public boolean hasJobFilterExtensions() {
+        return !ViewJobFilter.all().isEmpty();
+    }
+
 	@Override
 	public SectionedViewSection newInstance(StaplerRequest req, JSONObject formData) throws FormException {
 		SectionedViewSection section = (SectionedViewSection)req.bindJSON(getClass().getDeclaringClass(), formData);

--- a/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/config.jelly
@@ -49,7 +49,7 @@ THE SOFTWARE.
         </f:entry>
       </f:optionalBlock>
 
-	  <j:if test="${instance.hasJobFilterExtensions()}">
+	  <j:if test="${descriptor.hasJobFilterExtensions()}">
 	   <j:invokeStatic var="allJobFilters" className="hudson.views.ViewJobFilter" method="all"/>
 	   <f:block>
 	      <f:hetero-list name="jobFilters" hasHeader="true"

--- a/src/main/resources/hudson/plugins/sectioned_view/SectionedViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/SectionedViewSection/config.jelly
@@ -43,7 +43,7 @@ THE SOFTWARE.
         </j:forEach>
       </f:entry>
 
-	  <j:if test="${instance.hasJobFilterExtensions()}">
+	  <j:if test="${descriptor.hasJobFilterExtensions()}">
 	   <j:invokeStatic var="allJobFilters" className="hudson.views.ViewJobFilter" method="all"/>
 	   <f:block>
 	      <f:hetero-list name="jobFilters" hasHeader="true"


### PR DESCRIPTION
…m SectionedViewSection to SectionedViewSectionDescriptor.

The config.jelly file was previously attempting to invoke this method in SectionedViewSection via the 'instance'
reference.  However the 'instance' does not exist until the new section is saved.  Because of this the
'Add Job Filter' button could never appear until after the view was saved and re-opened for editing.

By moving the method to the SectionedViewSectionDescriptor class it is available before the section is created by the first save.