### PR TITLE
Fix job filters in list view section for jobs in folders.

### DIFF
--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
@@ -179,7 +179,7 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
 
         // check the filters
         Iterable<ViewJobFilter> jobFilters = getJobFilters();
-        List<TopLevelItem> allItems = new ArrayList<TopLevelItem>(itemGroup.getItems());
+        List<TopLevelItem> allItems = Items.getAllItems(itemGroup, TopLevelItem.class);
         for (ViewJobFilter jobFilter: jobFilters) {
             items = jobFilter.filter(items, allItems, null);
         }


### PR DESCRIPTION
It is possible to filter the output of the ListViewSection using:

- A check list of jobs and folders.
- A regular expression.
- The output of the above two options is combined.  If the
  https://wiki.jenkins-ci.org/display/JENKINS/View+Job+Filters plugin is installed then
  additional filters can be applied that act upon the output of the first two options.

However the interaction between these two plugins was probably developed before the advent
of the CloudBees Folder Plugin.

The method that applies the filters requires a list of 'all items'.  With Jenkins native 'flat' item
structure the original method for obtaining this was sufficient.  However when the CloudBees Folder Plugin is
installed the method that obtains the 'all items' list needs to collect the items on that level AND all their children.

This turned out to be a simple fix.  All that was required was to change the built in method used to provide the
'all items' list.