### PR TITLE
Scan all items for matching regular expression

### DIFF
--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
@@ -175,7 +175,7 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
     public Collection<TopLevelItem> getItems(ItemGroup<? extends TopLevelItem> itemGroup) {
         SortedSet<String> names = new TreeSet<String>(jobNames);
 
-        Collection<? extends TopLevelItem> topLevelItems = itemGroup.getItems();
+        Collection<? extends TopLevelItem> topLevelItems = Items.getAllItems(itemGroup, TopLevelItem.class);
         if (includePattern != null) {
             for (TopLevelItem item : topLevelItems) {
                 String itemName = item.getRelativeNameFrom(itemGroup);


### PR DESCRIPTION
The pull request https://github.com/jenkinsci/sectioned-view-plugin/pull/7 changed the behavior of the plugin to select only a subset of job items for regular expression matching. If there are jobs that are stored in Folders they can't be selected any more via a regulare expression. This change selects now all jobs, also the jobs that are located in Folders.