### PR TITLE
Option to execute the regeluar expression on all jobs

### DIFF
--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
@@ -175,7 +175,7 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
     public Collection<TopLevelItem> getItems(ItemGroup<? extends TopLevelItem> itemGroup) {
         SortedSet<String> names = new TreeSet<String>(jobNames);
 
-        Collection<? extends TopLevelItem> topLevelItems = itemGroup.getItems();
+        Collection<? extends TopLevelItem> topLevelItems = Items.getAllItems(itemGroup, TopLevelItem.class);
         if (includePattern != null) {
             for (TopLevelItem item : topLevelItems) {
                 String itemName = item.getRelativeNameFrom(itemGroup);

--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
@@ -72,6 +72,12 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
      * Include regex string.
      */
     String includeRegex;
+    
+    /**
+     * execute regex on all jobs
+     */
+    
+    boolean executingRegexOnAllJobs;
 
     /**
      * Compiled include pattern from the includeRegex string.
@@ -108,6 +114,14 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
         includePattern = Pattern.compile(regex);
     }
 
+    public boolean isExecutingRegexOnAllJobs() {
+        return executingRegexOnAllJobs;
+    }
+    
+    public void setExecutingRegexOnAllJobs(boolean value) {
+        this.executingRegexOnAllJobs = value;
+    }
+    
     public Iterable<ViewJobFilter> getJobFilters() {
         return jobFilters;
     }
@@ -175,7 +189,13 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
     public Collection<TopLevelItem> getItems(ItemGroup<? extends TopLevelItem> itemGroup) {
         SortedSet<String> names = new TreeSet<String>(jobNames);
 
-        Collection<? extends TopLevelItem> topLevelItems = Items.getAllItems(itemGroup, TopLevelItem.class);
+        Collection<? extends TopLevelItem> topLevelItems = null;
+        if(executingRegexOnAllJobs) {
+            topLevelItems = Items.getAllItems(itemGroup, TopLevelItem.class);
+        } else {
+            topLevelItems = itemGroup.getItems();
+        }
+        
         if (includePattern != null) {
             for (TopLevelItem item : topLevelItems) {
                 String itemName = item.getRelativeNameFrom(itemGroup);

--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSectionDescriptor.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSectionDescriptor.java
@@ -70,6 +70,7 @@ public abstract class SectionedViewSectionDescriptor extends Descriptor<Sectione
             } catch (PatternSyntaxException e) {
                 throw new FormException("Regular expression is invalid: " + e.getMessage(), e, "includeRegex");
             }
+            section.setExecutingRegexOnAllJobs(merp.getBoolean("executingRegexOnAllJobs"));
         } else {
             section.includeRegex = null;
             section.includePattern = null;

--- a/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/config.jelly
@@ -51,6 +51,9 @@ THE SOFTWARE.
         <f:entry title="${%Regular expression}" field="includeRegex">
           <f:textbox />
         </f:entry>
+		<f:entry title="${%Query all jobs?}" field="executingRegexOnAllJobs">
+		    <f:checkbox/>
+		</f:entry>        
       </f:optionalBlock>
 
 	  <j:if test="${descriptor.hasJobFilterExtensions()}">

--- a/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/help-executingRegexOnAllJobs.html
+++ b/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/help-executingRegexOnAllJobs.html
@@ -1,0 +1,1 @@
+By enabling this option all jobs will be checked by the regular expression.

--- a/src/main/resources/hudson/plugins/sectioned_view/SectionedViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/SectionedViewSection/config.jelly
@@ -60,6 +60,9 @@ THE SOFTWARE.
         <f:entry title="${%Regular expression}" field="includeRegex">
           <f:textbox />
         </f:entry>
+		<f:entry title="${%Query all jobs?}" field="executingRegexOnAllJobs">
+		    <f:checkbox/>
+		</f:entry>        
       </f:optionalBlock>
       
     </f:advanced>


### PR DESCRIPTION
I implemented the option to execute the regular expression on all jobs. Now it is possible to select this option during configuration of a section. If this option is enabled the plugin behaves like the old logic. 
The idea of doing this implementation comes from the diskussion in pull request https://github.com/jenkinsci/sectioned-view-plugin/pull/7 where the behavior of the job selection was changed and the idea of an optional opt-in for the old behavior was suggested.