### PR TITLE
JENKINS-37174 fix: make relative job name calculation work again

### DIFF
--- a/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/main.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/main.jelly
@@ -43,6 +43,7 @@ THE SOFTWARE.
       <st:nbsp/>
     </th>
   </tr>
+  <j:set var="itemGroup" value="${it.ownerItemGroup}"/>
   <j:forEach var="job" items="${sectionItems}">
     <j:set var="relativeLinkToJob" value="${h.getRelativeLinkTo(job)}"/>
     <t:projectViewRow jobBaseUrl="${relativeLinkToJob.substring(0, relativeLinkToJob.length() - job.shortUrl.length())}"/>


### PR DESCRIPTION
Restore the `itemGroup` var used by column Jelly template to calculate relative job names. Without it the jobs in this view display as "Folder » Job" instead of just "Job" when the view is in a folder.