### PR TITLE
[JENKINS-45038] Fix getting all children items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       <optional>true</optional>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>5.18</version>
+      <version>4.10</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
@@ -175,7 +175,7 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
     public Collection<TopLevelItem> getItems(ItemGroup<? extends TopLevelItem> itemGroup) {
         SortedSet<String> names = new TreeSet<String>(jobNames);
 
-        Collection<? extends TopLevelItem> topLevelItems = itemGroup.getItems();
+        Collection<? extends TopLevelItem> topLevelItems = Items.getAllItems(itemGroup, TopLevelItem.class);
         if (includePattern != null) {
             for (TopLevelItem item : topLevelItems) {
                 String itemName = item.getRelativeNameFrom(itemGroup);


### PR DESCRIPTION
`ItemGroup#getItems` methods is limited to current level elements, when we need to
have all the children elements, even contained in folders.