### PR TITLE
[JENKINS-58418] Improve escaping of job names in configure form

### DIFF
--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSectionDescriptor.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSectionDescriptor.java
@@ -82,7 +82,7 @@ public abstract class SectionedViewSectionDescriptor extends Descriptor<Sectione
         }
 
         for (TopLevelItem item : Items.getAllItems(group, TopLevelItem.class)) {
-            String escapedName = item.getRelativeNameFrom(group).replaceAll("\\.", "_");
+            String escapedName = escapeJobName(item.getRelativeNameFrom(group));
             if (formData.containsKey(escapedName) && formData.getBoolean(escapedName))
                 section.jobNames.add(item.getRelativeNameFrom(group));
         }
@@ -112,6 +112,25 @@ public abstract class SectionedViewSectionDescriptor extends Descriptor<Sectione
             }
         }
         return FormValidation.ok();
+    }
+
+    /**
+     * Utility method which escapes job names so that they can be safely
+     * inserted into the name field of HTML inputs. Escaping is needed since
+     * job names may contain characters which have special meaning in name
+     * fields of HTML inputs. For example the dot (.) character, in a name
+     * field Jenkins input handling (Stapler) will treat the dot as an
+     * hierarchical separation and split the name on the dot, which in this
+     * case is unwanted. So in order to mitigate that dots are replaces with a
+     * character which are disallowed in job names and have no special meaning
+     * in input fields, e.g. hash tag (#).
+     *
+     * @param name Job name to be escaped before insertion into HTML input name
+     * @return Escaped job name
+     */
+    public static String escapeJobName(String name) {
+        // For a list of forbidden job name characters, see jenkins.model.Jenkins#checkGoodName()
+        return name.replaceAll("\\.", "#");
     }
 
 }

--- a/src/main/resources/hudson/plugins/sectioned_view/FolderViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/FolderViewSection/config.jelly
@@ -29,9 +29,7 @@ THE SOFTWARE.
             <j:forEach var="item" items="${items}">
                 <j:if test="${descriptor.isFolder(item)}">
                     <j:set var="itemName" value="${prefix == ''?'':prefix+'$'}${item.name}"/>
-                    <j:set var="escapeRegEx" value="\."/>
-                    <j:set var="replaceString" value="_"/>
-                    <j:set var="name" value="sections.${h.getRelativeNameFrom(item, it.ownerItemGroup, false).replaceAll(escapeRegEx, replaceString)}"/>
+                    <j:set var="name" value="sections.${descriptor.escapeJobName(h.getRelativeNameFrom(item, it.ownerItemGroup, false))}"/>
                     items['${itemName}'] = new YAHOO.widget.HTMLNode('&lt;input type="checkbox" name="${name}" '+has("${itemName}")+'/&gt;&lt;label class="attach-previous"&gt;${h.jsStringEscape(item.name)}&lt;/label&gt;', ${parentNode}, false);
                     <j:if test="${item.items != null}">
                         <local:add-children parentNode="items['${itemName}']" items="${item.items}" prefix="${itemName}"/>

--- a/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/ListViewSection/config.jelly
@@ -36,10 +36,8 @@ THE SOFTWARE.
       </f:entry>
       <f:entry title="${%Jobs}">
         <div class="listview-jobs">
-          <j:set var="escapeRegEx" value="\."/>
-          <j:set var="replaceString" value="_"/>
           <j:forEach var="job" items="${h.getAllTopLevelItems(it.ownerItemGroup)}">
-            <f:checkbox name='sections.${h.getRelativeNameFrom(job, it.ownerItemGroup, false).replaceAll(escapeRegEx, replaceString)}' checked="${instance.contains(job, it.ownerItemGroup)}" />
+            <f:checkbox name='sections.${descriptor.escapeJobName(h.getRelativeNameFrom(job, it.ownerItemGroup, false))}' checked="${instance.contains(job, it.ownerItemGroup)}" />
             <label class="attach-previous">${h.getRelativeNameFrom(job, it.ownerItemGroup, true)}</label>
             <br/>
           </j:forEach>

--- a/src/main/resources/hudson/plugins/sectioned_view/SectionedViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/SectionedViewSection/config.jelly
@@ -36,10 +36,8 @@ THE SOFTWARE.
       </f:entry>
 
       <f:entry title="${%Jobs}">
-        <j:set var="escapeRegEx" value="\."/>
-        <j:set var="replaceString" value="_"/>
         <j:forEach var="job" items="${h.getAllTopLevelItems(it.ownerItemGroup)}">
-          <f:checkbox name='sections.${job.name.replaceAll(escapeRegEx, replaceString)}' checked="${instance.contains(job)}" />
+          <f:checkbox name='sections.${descriptor.escapeJobName(job.name)}' checked="${instance.contains(job)}" />
           <label class="attach-previous">${h.getRelativeNameFrom(job, it.ownerItemGroup, true)}</label>
           <br/>
         </j:forEach>


### PR DESCRIPTION
Changed escape character to one which has no special meaning in name
attribute for input fields and is disallowed in job names. The previous
escape character causes exceptions if there were two jobs where the
only difference in the name was a dot instead of an underscore.