### PR TITLE
Migrate from `hudson.util.CaseInsensitiveComparator` to Java `String.CASE_INSENSITIVE_ORDER`

### DIFF
--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
@@ -32,7 +32,6 @@ import hudson.model.ItemGroup;
 import hudson.model.Items;
 import hudson.model.Saveable;
 import hudson.model.TopLevelItem;
-import hudson.util.CaseInsensitiveComparator;
 import hudson.util.DescribableList;
 import hudson.util.EnumConverter;
 import hudson.views.ViewJobFilter;
@@ -63,7 +62,7 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
     /**
      * List of job names. This is what gets serialized.
      */
-    /*package*/ final SortedSet<String> jobNames = new TreeSet<String>(CaseInsensitiveComparator.INSTANCE);
+    /*package*/ final SortedSet<String> jobNames = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
     /*package*/ DescribableList<ViewJobFilter, Descriptor<ViewJobFilter>> jobFilters;
 
     private String name;


### PR DESCRIPTION
See jenkinsci/jenkins#5569. Migrates from `hudson.util.CaseInsensitiveComparator` to Java's native `String.CASE_INSENSITIVE_ORDER`.