### PR TITLE
fix prototype usage

### DIFF
--- a/src/main/resources/hudson/plugins/sectioned_view/FolderViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/FolderViewSection/config.jelly
@@ -53,7 +53,7 @@ THE SOFTWARE.
                     var values = (e.getAttribute("values") || "").split(",");
 
                     function has(v) {
-                        return values.include(v) ? 'checked="true" ' : "";
+                        return values.includes(v) ? 'checked="true" ' : "";
                     }
                     var items = {};
 

--- a/src/main/resources/hudson/plugins/sectioned_view/ViewListingSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/ViewListingSection/config.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
 
           var values = (e.getAttribute("values") || "").split(",");
           function has(v) {
-            return values.include(v) ? 'checked="checked" ' : "";
+            return values.includes(v) ? 'checked="checked" ' : "";
           }
           var views = {};
           <local:add-children parentView="root" views="${it.owner.views}" prefix=""/>


### PR DESCRIPTION
`values.include(` is protoytype syntax and not working with Jenkins >= 2.426.x
replace it with the pure javascript method that should work with all modern browsers

<!-- Please describe your pull request here. -->

### Testing done
verified that with 2.426.3 the folder selection is working, without this fix it is not working and an error can be seen in the browser console

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
