### PR TITLE
[JENKINS-75013] remove loading of yui treeview

### DIFF
--- a/src/main/resources/hudson/plugins/sectioned_view/SectionedView/configure-entries.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/SectionedView/configure-entries.jelly
@@ -27,10 +27,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <!-- Needed for ViewListingSection, but including these from ViewListingSection/config.jelly is too late -->
-  <l:yui module="treeview" />
-  <link rel="stylesheet" type="text/css"
-        href="${rootURL}/scripts/yui/treeview/assets/skins/sam/treeview.css" />
   <f:section title="Sections">
     <j:invokeStatic var="allSections" className="hudson.plugins.sectioned_view.SectionedViewSection" method="all"/>
     <f:block>


### PR DESCRIPTION
In #38 I missed to remove loading of yui treeview module which is no longer required.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
