### PR TITLE
remove usage of commons lang 2

### DIFF
--- a/src/main/java/hudson/plugins/sectioned_view/FolderViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/FolderViewSection.java
@@ -30,11 +30,8 @@ import hudson.Util;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
-import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -212,22 +209,6 @@ public class FolderViewSection extends SectionedViewSection {
         @Override
         public String getDisplayName() {
             return "Folder Listing Section";
-        }
-
-        public FormValidation doCheckViewColumns(@QueryParameter String value) {
-            if (StringUtils.isNotEmpty(value) && StringUtils.isNumeric(value)) {
-                int columns = Integer.parseInt(value);
-                if (columns > 0) return FormValidation.ok();
-            }
-            return FormValidation.error("Columns must be a number greater than 0");
-        }
-
-        public FormValidation doCheckFolderLevels(@QueryParameter String value) {
-            if (StringUtils.isNotEmpty(value) && StringUtils.isNumeric(value)) {
-                int columns = Integer.parseInt(value);
-                if (columns > 0) return FormValidation.ok();
-            }
-            return FormValidation.error("Levels must be a number greater than 0");
         }
 
         public Collection<Item> getAllFolders(ItemGroup<Item> itemGroup) {

--- a/src/main/java/hudson/plugins/sectioned_view/ViewListingSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/ViewListingSection.java
@@ -28,17 +28,11 @@ import java.util.Collection;
 import java.util.List;
 
 import hudson.Extension;
-import hudson.model.Hudson;
 import hudson.model.View;
 import hudson.model.ViewGroup;
-import hudson.util.FormValidation;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import net.sf.json.JSONObject;
 
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
 
 public class ViewListingSection extends SectionedViewSection {
@@ -122,12 +116,5 @@ public class ViewListingSection extends SectionedViewSection {
             return "View Listing Section";
         }
         
-        public FormValidation doCheckColumns(@QueryParameter String value) {
-            if (StringUtils.isNotEmpty(value) && StringUtils.isNumeric(value)) {
-                int columns = Integer.parseInt(value);
-                if (columns > 0) return FormValidation.ok();
-            }
-            return FormValidation.error("Columns must be a number greater than 0");
-        }
     }
 }

--- a/src/main/resources/hudson/plugins/sectioned_view/FolderViewSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/FolderViewSection/config.jelly
@@ -66,10 +66,10 @@ THE SOFTWARE.
                 <f:enum>${it.description}</f:enum>
             </f:entry>
             <f:entry field="viewColumns" title="${%Columns}">
-                <f:textbox default="1"/>
+                <f:number default="1" clazz="required positive-number" min="1"/>
             </f:entry>
             <f:entry field="folderLevels" title="${%Levels}">
-                <f:textbox default="10"/>
+                <f:number default="10" clazz="required positive-number" min="1"/>
             </f:entry>
             <f:entry field="hideJobs" title="${%Hide Jobs}">
                 <f:checkbox name="hideJobs" default="true" checked="${it.hideJobs}"/>

--- a/src/main/resources/hudson/plugins/sectioned_view/ViewListingSection/config.jelly
+++ b/src/main/resources/hudson/plugins/sectioned_view/ViewListingSection/config.jelly
@@ -66,7 +66,7 @@ THE SOFTWARE.
         <f:enum>${it.description}</f:enum>
       </f:entry>
       <f:entry field="columns" title="${%Columns}">
-        <f:textbox default="1"/>
+        <f:number default="1" clazz="required positive-number" min="1"/>
       </f:entry>
     </f:advanced>
   </f:nested>


### PR DESCRIPTION
usage was only to validate that form field values are positive integers. This can be achieved by using <`f:number` with corresponding attributes instead of check methods

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
