### PR TITLE
Feature JENKINS-59551: Added support for setting columns in sectioned views through JCasC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <optional>true</optional>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>

--- a/src/main/java/hudson/plugins/sectioned_view/ListViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/ListViewSection.java
@@ -51,7 +51,6 @@ import java.util.logging.Logger;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest2;
 
 public class ListViewSection extends SectionedViewSection {
@@ -68,7 +67,6 @@ public class ListViewSection extends SectionedViewSection {
         return columns;
     }
 
-    @DataBoundSetter
     public void setColumns(List<ListViewColumn> columns) throws IOException {
         if (this.columns == null) {
             this.columns = new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP);

--- a/src/main/java/hudson/plugins/sectioned_view/ListViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/ListViewSection.java
@@ -57,7 +57,7 @@ import org.kohsuke.stapler.StaplerRequest2;
 public class ListViewSection extends SectionedViewSection {
 
     private DescribableList<ListViewColumn, Descriptor<ListViewColumn>> columns =
-            new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP);
+            new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP, getDefaultColumns());
 
     @DataBoundConstructor
     public ListViewSection(String name, Width width, Positioning alignment) {
@@ -79,7 +79,7 @@ public class ListViewSection extends SectionedViewSection {
     protected Object readResolve() {
         super.readResolve();
         if (columns == null) {
-            columns = new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP);
+            columns = new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP, getDefaultColumns());
         }
         return this;
     }

--- a/src/main/java/hudson/plugins/sectioned_view/ListViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/ListViewSection.java
@@ -77,6 +77,7 @@ public class ListViewSection extends SectionedViewSection {
     }
 
     protected Object readResolve() {
+        super.readResolve();
         if (columns == null) {
             columns = new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP);
         }

--- a/src/main/java/hudson/plugins/sectioned_view/ListViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/ListViewSection.java
@@ -51,11 +51,13 @@ import java.util.logging.Logger;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest2;
 
 public class ListViewSection extends SectionedViewSection {
 
-    private DescribableList<ListViewColumn, Descriptor<ListViewColumn>> columns;
+    private DescribableList<ListViewColumn, Descriptor<ListViewColumn>> columns =
+            new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP);
 
     @DataBoundConstructor
     public ListViewSection(String name, Width width, Positioning alignment) {
@@ -64,6 +66,21 @@ public class ListViewSection extends SectionedViewSection {
 
     public Iterable<ListViewColumn> getColumns() {
         return columns;
+    }
+
+    @DataBoundSetter
+    public void setColumns(List<ListViewColumn> columns) throws IOException {
+        if (this.columns == null) {
+            this.columns = new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP);
+        }
+        this.columns.replaceBy(columns);
+    }
+
+    protected Object readResolve() {
+        if (columns == null) {
+            columns = new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(Saveable.NOOP);
+        }
+        return this;
     }
 
     @SuppressFBWarnings(value = "NP_NONNULL_PARAM_VIOLATION", justification = "TODO needs triage")

--- a/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
+++ b/src/main/java/hudson/plugins/sectioned_view/SectionedViewSection.java
@@ -38,7 +38,9 @@ import hudson.views.ViewJobFilter;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
@@ -150,6 +152,15 @@ public abstract class SectionedViewSection implements ExtensionPoint, Describabl
 
     public boolean contains(TopLevelItem item, ItemGroup<? extends TopLevelItem> itemGroup) {
         return jobNames.contains(item.getRelativeNameFrom(itemGroup));
+    }
+
+    public Set<String> getJobNames() {
+        return Collections.unmodifiableSet(jobNames);
+    }
+
+    public void setJobNames(Collection<String> jobNames) {
+        this.jobNames.clear();
+        this.jobNames.addAll(jobNames);
     }
 
     protected Object readResolve() {

--- a/src/test/java/hudson/plugins/sectioned_view/ListViewSectionJCasCTest.java
+++ b/src/test/java/hudson/plugins/sectioned_view/ListViewSectionJCasCTest.java
@@ -36,4 +36,13 @@ class ListViewSectionJCasCTest {
                 "StatusColumn", "JobColumn", "LastSuccessColumn",
                 "LastFailureColumn", "LastDurationColumn"));
     }
+
+    @Test
+    @ConfiguredWithCode("no-columns.yaml")
+    @Issue("JENKINS-59551")
+    void omittedColumnsFallBackToDefaults(JenkinsConfiguredWithCodeRule r) {
+        assertThat(columnClassNames(firstSection(r)), contains(
+                "StatusColumn", "WeatherColumn", "JobColumn", "LastSuccessColumn",
+                "LastFailureColumn", "LastDurationColumn", "BuildButtonColumn"));
+    }
 }

--- a/src/test/java/hudson/plugins/sectioned_view/ListViewSectionJCasCTest.java
+++ b/src/test/java/hudson/plugins/sectioned_view/ListViewSectionJCasCTest.java
@@ -2,10 +2,12 @@ package hudson.plugins.sectioned_view;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.views.ListViewColumn;
 import io.jenkins.plugins.casc.ConfigurationContext;
@@ -65,5 +67,15 @@ class ListViewSectionJCasCTest {
         assertThat(exported, containsString("listViewSection"));
         assertThat(exported, stringContainsInOrder("columns",
                 "status", "jobName", "lastSuccess", "lastFailure", "lastDuration"));
+    }
+
+    @Test
+    @ConfiguredWithCode("jobnames.yaml")
+    @Issue("JENKINS-59551")
+    void jobNamesAreBoundFromYaml(JenkinsConfiguredWithCodeRule r) {
+        ListViewSection section = firstSection(r);
+        assertThat(section.getJobNames(), containsInAnyOrder("Job Alpha", "Job Beta"));
+        assertTrue(section.getJobNames().contains("job alpha"),
+                "job name lookup must stay case-insensitive");
     }
 }

--- a/src/test/java/hudson/plugins/sectioned_view/ListViewSectionJCasCTest.java
+++ b/src/test/java/hudson/plugins/sectioned_view/ListViewSectionJCasCTest.java
@@ -1,0 +1,39 @@
+package hudson.plugins.sectioned_view;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import hudson.views.ListViewColumn;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+
+@WithJenkinsConfiguredWithCode
+class ListViewSectionJCasCTest {
+
+    private static List<String> columnClassNames(ListViewSection section) {
+        List<String> names = new ArrayList<>();
+        for (ListViewColumn c : section.getColumns()) {
+            names.add(c.getClass().getSimpleName());
+        }
+        return names;
+    }
+
+    private static ListViewSection firstSection(JenkinsConfiguredWithCodeRule r) {
+        SectionedView view = (SectionedView) r.jenkins.getView("test");
+        return (ListViewSection) view.getSections().iterator().next();
+    }
+
+    @Test
+    @ConfiguredWithCode("columns.yaml")
+    @Issue("JENKINS-59551")
+    void columnsAreBoundFromYaml(JenkinsConfiguredWithCodeRule r) {
+        assertThat(columnClassNames(firstSection(r)), contains(
+                "StatusColumn", "JobColumn", "LastSuccessColumn",
+                "LastFailureColumn", "LastDurationColumn"));
+    }
+}

--- a/src/test/java/hudson/plugins/sectioned_view/ListViewSectionJCasCTest.java
+++ b/src/test/java/hudson/plugins/sectioned_view/ListViewSectionJCasCTest.java
@@ -2,11 +2,18 @@ package hudson.plugins.sectioned_view;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 
 import hudson.views.ListViewColumn;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import io.jenkins.plugins.casc.model.CNode;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -44,5 +51,19 @@ class ListViewSectionJCasCTest {
         assertThat(columnClassNames(firstSection(r)), contains(
                 "StatusColumn", "WeatherColumn", "JobColumn", "LastSuccessColumn",
                 "LastFailureColumn", "LastDurationColumn", "BuildButtonColumn"));
+    }
+
+    @Test
+    @ConfiguredWithCode("columns.yaml")
+    @Issue("JENKINS-59551")
+    void exportRoundTripsColumns(JenkinsConfiguredWithCodeRule r) throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode viewsNode = getJenkinsRoot(context).get("views");
+        String exported = toYamlString(viewsNode);
+
+        assertThat(exported, containsString("listViewSection"));
+        assertThat(exported, stringContainsInOrder("columns",
+                "status", "jobName", "lastSuccess", "lastFailure", "lastDuration"));
     }
 }

--- a/src/test/java/hudson/plugins/sectioned_view/ListViewSectionReadResolveTest.java
+++ b/src/test/java/hudson/plugins/sectioned_view/ListViewSectionReadResolveTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.sectioned_view;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -9,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import hudson.plugins.sectioned_view.SectionedViewSection.Positioning;
 import hudson.plugins.sectioned_view.SectionedViewSection.Width;
+import java.util.ArrayList;
+import java.util.List;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,5 +53,23 @@ class ListViewSectionReadResolveTest {
 
         ListViewSection loaded = (ListViewSection) Jenkins.XSTREAM2.fromXML(legacyXml);
         assertDoesNotThrow(() -> loaded.getItems(j.jenkins));
+    }
+
+    @Test
+    @Issue("JENKINS-59551")
+    void legacyConfigWithoutColumnsGetsDefaultColumns() throws Exception {
+        ListViewSection original = new ListViewSection("lvs", Width.THIRD, Positioning.CENTER);
+        String xml = Jenkins.XSTREAM2.toXML(original);
+        String legacyXml = xml.replaceFirst("(?s)<columns>.*?</columns>|<columns/>", "");
+        assertThat("setup: columns element must be stripped", legacyXml, not(containsString("<columns")));
+
+        ListViewSection loaded = (ListViewSection) Jenkins.XSTREAM2.fromXML(legacyXml);
+        List<String> names = new ArrayList<>();
+        for (hudson.views.ListViewColumn c : loaded.getColumns()) {
+            names.add(c.getClass().getSimpleName());
+        }
+        assertThat(names, contains(
+                "StatusColumn", "WeatherColumn", "JobColumn", "LastSuccessColumn",
+                "LastFailureColumn", "LastDurationColumn", "BuildButtonColumn"));
     }
 }

--- a/src/test/java/hudson/plugins/sectioned_view/ListViewSectionReadResolveTest.java
+++ b/src/test/java/hudson/plugins/sectioned_view/ListViewSectionReadResolveTest.java
@@ -1,0 +1,54 @@
+package hudson.plugins.sectioned_view;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import hudson.plugins.sectioned_view.SectionedViewSection.Positioning;
+import hudson.plugins.sectioned_view.SectionedViewSection.Width;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class ListViewSectionReadResolveTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void beforeEach(JenkinsRule rule) {
+        j = rule;
+    }
+
+    @Test
+    @Issue("JENKINS-59551")
+    void readResolveRestoresTransientState() throws Exception {
+        ListViewSection original = new ListViewSection("lvs", Width.THIRD, Positioning.CENTER);
+        original.setIncludeRegex(".*foo.*");
+
+        String xml = Jenkins.XSTREAM2.toXML(original);
+        ListViewSection loaded = (ListViewSection) Jenkins.XSTREAM2.fromXML(xml);
+
+        assertThat(loaded.getIncludeRegex(), is(".*foo.*"));
+        assertThat("css must be recomputed on load", loaded.getCss(), notNullValue());
+        assertThat("includePattern must be recompiled on load", loaded.includePattern, notNullValue());
+    }
+
+    @Test
+    @Issue("JENKINS-59551")
+    void legacyConfigWithoutJobFiltersDoesNotBreakGetItems() throws Exception {
+        ListViewSection original = new ListViewSection("lvs", Width.THIRD, Positioning.CENTER);
+        String xml = Jenkins.XSTREAM2.toXML(original);
+        String legacyXml = xml.replaceFirst("(?s)<jobFilters>.*?</jobFilters>|<jobFilters/>", "");
+        assertThat("setup: jobFilters element must be stripped", legacyXml, not(containsString("jobFilters")));
+
+        ListViewSection loaded = (ListViewSection) Jenkins.XSTREAM2.fromXML(legacyXml);
+        assertDoesNotThrow(() -> loaded.getItems(j.jenkins));
+    }
+}

--- a/src/test/java/hudson/plugins/sectioned_view/ListViewSectionSaveTest.java
+++ b/src/test/java/hudson/plugins/sectioned_view/ListViewSectionSaveTest.java
@@ -1,0 +1,92 @@
+package hudson.plugins.sectioned_view;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import hudson.plugins.sectioned_view.SectionedViewSection.Positioning;
+import hudson.plugins.sectioned_view.SectionedViewSection.Width;
+import hudson.views.ListViewColumn;
+import hudson.views.ListViewColumnDescriptor;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest2;
+
+@WithJenkins
+class ListViewSectionSaveTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void beforeEach(JenkinsRule rule) {
+        j = rule;
+    }
+
+    /** Models a legacy/third-party column: no @DataBoundConstructor, descriptor overrides newInstance. */
+    public static class LegacyColumn extends ListViewColumn {
+        @TestExtension("legacyColumnSurvivesViewSave")
+        public static class DescriptorImpl extends ListViewColumnDescriptor {
+            @Override
+            public ListViewColumn newInstance(StaplerRequest2 req, JSONObject formData) {
+                return new LegacyColumn();
+            }
+
+            @Override
+            public String getDisplayName() {
+                return "Legacy Column";
+            }
+        }
+    }
+
+    public static class CountingColumn extends ListViewColumn {
+        static final AtomicInteger CONSTRUCTIONS = new AtomicInteger();
+
+        @DataBoundConstructor
+        public CountingColumn() {
+            CONSTRUCTIONS.incrementAndGet();
+        }
+
+        @TestExtension("viewSaveConstructsEachColumnOnce")
+        public static class DescriptorImpl extends ListViewColumnDescriptor {
+            @Override
+            public String getDisplayName() {
+                return "Counting Column";
+            }
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-59551")
+    void legacyColumnSurvivesViewSave() throws Exception {
+        SectionedView view = new SectionedView("sw");
+        j.jenkins.addView(view);
+        ListViewSection section = new ListViewSection("lvs", Width.FULL, Positioning.CENTER);
+        section.setColumns(List.of(new LegacyColumn()));
+        view.setSections(List.of(section));
+
+        assertDoesNotThrow(() -> j.configRoundtrip(view));
+    }
+
+    @Test
+    @Issue("JENKINS-59551")
+    void viewSaveConstructsEachColumnOnce() throws Exception {
+        SectionedView view = new SectionedView("sw");
+        j.jenkins.addView(view);
+        ListViewSection section = new ListViewSection("lvs", Width.FULL, Positioning.CENTER);
+        section.setColumns(List.of(new CountingColumn()));
+        view.setSections(List.of(section));
+
+        CountingColumn.CONSTRUCTIONS.set(0);
+        j.configRoundtrip(view);
+
+        assertThat(CountingColumn.CONSTRUCTIONS.get(), is(1));
+    }
+}

--- a/src/test/resources/hudson/plugins/sectioned_view/columns.yaml
+++ b/src/test/resources/hudson/plugins/sectioned_view/columns.yaml
@@ -1,0 +1,15 @@
+jenkins:
+  views:
+    - sectioned:
+        name: "test"
+        sections:
+          - listViewSection:
+              name: "section-one"
+              width: FULL
+              alignment: CENTER
+              columns:
+                - "status"
+                - "jobName"
+                - "lastSuccess"
+                - "lastFailure"
+                - "lastDuration"

--- a/src/test/resources/hudson/plugins/sectioned_view/jobnames.yaml
+++ b/src/test/resources/hudson/plugins/sectioned_view/jobnames.yaml
@@ -1,0 +1,12 @@
+jenkins:
+  views:
+    - sectioned:
+        name: "test"
+        sections:
+          - listViewSection:
+              name: "section-one"
+              width: FULL
+              alignment: CENTER
+              jobNames:
+                - "Job Alpha"
+                - "Job Beta"

--- a/src/test/resources/hudson/plugins/sectioned_view/no-columns.yaml
+++ b/src/test/resources/hudson/plugins/sectioned_view/no-columns.yaml
@@ -1,0 +1,9 @@
+jenkins:
+  views:
+    - sectioned:
+        name: "test"
+        sections:
+          - listViewSection:
+              name: "section-one"
+              width: FULL
+              alignment: CENTER


### PR DESCRIPTION
Hello,

the sectioned view plugin provides great visibility for the Jenkins GUI. However, as outlined in https://issues.jenkins.io/browse/JENKINS-59551, it does not support setting column names in JCasC files, which leads to empty views. The code changes in this PR allow to set columns in JCasC files identical to ListViews and solves the issue explained in JENKINS-59551. This is achieved by adding a DataBoundSetter (https://javadoc.jenkins.io/component/stapler/org/kohsuke/stapler/DataBoundSetter.html) for the `columns` key and a `readResolve` method for backwarts compatibility (https://www.jenkins.io/doc/developer/persistence/backward-compatibility/).

### Testing done
We tested these changes using:
- Jenkins Docker image 2.541.3 : https://hub.docker.com/layers/jenkins/jenkins/2.541.3-lts/images/sha256-827f56f02e09332a06638afa84068af39946066947e03cce95930ca598064384
- Sectioned-views-plugin 1.32
- JCasC Plugin configuration-as-code:2074.va_57f83f7a_10b_: https://updates.jenkins.io/download/plugins/configuration-as-code/
- All tests (mvn test, mvn verify) ran without issue.

Test procedure:
1. Section view plugin test **without** the changes of this PR.
    1.1. Using JCasC file (without `columns:`):
```
    .
    .
    .
    - sectioned:
        name: Test
        sections:
          - listViewSection:
              name: test1
              width: FULL
              alignment: CENTER
              includeRegex: ".*test1.*"
          - listViewSection:
              name: test2
              width: FULL
              alignment: CENTER
              includeRegex: ".*test2.**
```
--> Result: 
<img width="1548" height="199" alt="Bildschirmfoto vom 2026-07-07 13-54-38" src="https://github.com/user-attachments/assets/c069a520-8cbe-4633-a26c-442c55eadad7" />

   1.2. Using JCasC file (with `columns:` as in JCasC supported `ListView`):

```
    .
    .
    .
    - sectioned:
        name: Test
        sections:
          - listViewSection:
              name: test2
              width: FULL
              alignment: CENTER
              includeRegex: ".*test2.*"
              columns:
                - "statusColumn"
                - "weatherColumn"
                - "jobName"
                - "lastSuccess"
                - "lastFailure"
                - "lastDuration"
                - "buildButtonColumn"
          - listViewSection:
              name: test1
              width: FULL
              alignment: CENTER
              includeRegex: ".*test1.*"
              columns:
                - "statusColumn"
                - "weatherColumn"
                - "jobName"
                - "lastSuccess"
                - "lastFailure"
                - "lastDuration"
                - "buildButtonColumn"
```
--> Result: Error `columns:` is not a supported attribute of listViewSection

2. Section view plugin test **with** the changes of this PR. Using the same JCasC yaml as in 1.2:

--> Result:
<img width="1550" height="378" alt="Bildschirmfoto vom 2026-07-07 13-51-23" src="https://github.com/user-attachments/assets/9b00fd26-f558-42d3-8820-059a2c60f63f" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed